### PR TITLE
Indepth Optional System Params

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -177,7 +177,10 @@ impl<T: OptionalSystemParam> SystemParam for Option<T> {
 pub struct OptionState<T: SystemParamState>(T);
 
 /// SAFETY: T's SystemParamFetch implementation must be read-only.
-unsafe impl<T: SystemParamState + ReadOnlySystemParamFetch> ReadOnlySystemParamFetch for OptionState<T> {}
+unsafe impl<T: SystemParamState + ReadOnlySystemParamFetch> ReadOnlySystemParamFetch
+    for OptionState<T>
+{
+}
 
 pub type SystemParamItem<'w, 's, P> = <<P as SystemParam>::Fetch as SystemParamFetch<'w, 's>>::Item;
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -118,6 +118,9 @@ pub trait SystemParam: Sized {
 /// struct OptionParamState {
 ///     res_state: Option<ResState<SomeResource>>,
 /// }
+/// 
+/// // SAFETY: OptionParamState is constrained to read-only resources, so it only reads World.
+/// unsafe impl ReadOnlySystemParamFetch for OptionParamState {}
 ///
 /// unsafe impl SystemParamState for OptionParamState {
 ///     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -118,7 +118,7 @@ pub trait SystemParam: Sized {
 /// struct OptionParamState {
 ///     res_state: Option<ResState<SomeResource>>,
 /// }
-/// 
+///
 /// // SAFETY: OptionParamState is constrained to read-only resources, so it only reads World.
 /// unsafe impl ReadOnlySystemParamFetch for OptionParamState {}
 ///

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -105,7 +105,7 @@ pub trait SystemParam: Sized {
 /// # use bevy_ecs::prelude::*;
 /// # #[derive(Resource)]
 /// # struct SomeResource(u32);
-/// use bevy_ecs::system::{ReadOnlySystemParamFetch, SystemParam, SystemParamState, OptionalSystemParamFetch, SystemMeta, OptionalSystemParam, ResState};
+/// use bevy_ecs::system::{ReadOnlySystemParamFetch, SystemParam, OptionalSystemParam, SystemParamState, SystemParamFetch, OptionalSystemParamFetch, SystemMeta, ResState};
 ///
 /// struct MyOptionalParam<'w> {
 ///     foo: &'w u32,
@@ -122,7 +122,7 @@ pub trait SystemParam: Sized {
 /// unsafe impl SystemParamState for OptionParamState {
 ///     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {
 ///         Self {
-///             res_state: Some(OptionResState::init(world, system_meta))
+///             res_state: Some(ResState::init(world, system_meta))
 ///         }
 ///     }
 /// }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -176,7 +176,7 @@ impl<T: OptionalSystemParam> SystemParam for Option<T> {
 #[doc(hidden)]
 pub struct OptionState<T: SystemParamState>(T);
 
-/// SAFETY: T's SystemParamFetch implementation must be read-only.
+/// SAFETY: T's `SystemParamFetch` implementation must be read-only.
 unsafe impl<T: SystemParamState + ReadOnlySystemParamFetch> ReadOnlySystemParamFetch
     for OptionState<T>
 {
@@ -207,11 +207,11 @@ unsafe impl<T: SystemParamState> SystemParamState for OptionState<T> {
     }
     #[inline]
     fn new_archetype(&mut self, archetype: &Archetype, system_meta: &mut SystemMeta) {
-        self.0.new_archetype(archetype, system_meta)
+        self.0.new_archetype(archetype, system_meta);
     }
     #[inline]
     fn apply(&mut self, world: &mut World) {
-        self.0.apply(world)
+        self.0.apply(world);
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -256,7 +256,12 @@ where
         world: &'world World,
         change_tick: u32,
     ) -> Self::Item {
-        T::get_param(state, system_meta, world, change_tick).unwrap()
+        T::get_param(state, system_meta, world, change_tick).unwrap_or_else(|| {
+            panic!(
+                "Failed to get system param `{}`",
+                std::any::type_name::<T::Item>()
+            )
+        })
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -125,7 +125,7 @@ pub trait SystemParam: Sized {
 /// unsafe impl SystemParamState for OptionParamState {
 ///     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {
 ///         Self {
-///             res_state: Some(ResState::init(world, system_meta))
+///             res_state: OptionState::init(world, system_meta)
 ///         }
 ///     }
 /// }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -176,6 +176,7 @@ impl<T: OptionalSystemParam> SystemParam for Option<T> {
 #[doc(hidden)]
 pub struct OptionState<T: SystemParamState>(T);
 
+/// SAFETY: T's SystemParamFetch implementation must be read-only.
 unsafe impl<T: SystemParamState + ReadOnlySystemParamFetch> ReadOnlySystemParamFetch for OptionState<T> {}
 
 pub type SystemParamItem<'w, 's, P> = <<P as SystemParam>::Fetch as SystemParamFetch<'w, 's>>::Item;


### PR DESCRIPTION
# Objective

- There is boilerplate for `T` and `Option<T>` system params where you have to implement `SystemParamState` and `SystemParamFetch` for both types.

## Solution

- This removes that boilerplate by making it necessary to only implement `SystemParam` or `OptionalSystemParam` and their respective traits.
